### PR TITLE
Added assert as a runtime check if the API user passes invalid channe…

### DIFF
--- a/pimp.h
+++ b/pimp.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #ifdef USE_TYPEDEFS
 typedef uint64_t u64;
@@ -51,6 +52,7 @@ typedef struct {
 void save_image(Image* image, char* file_name);
 uint32_t get_image_size(Image* image);
 Image create_image(uint32_t width, uint32_t height);
+uint32_t *bmp_alpha_to_rgba_channels(uint8_t *src_image, int32_t w, int32_t h);
 uint8_t bmp_write(const char *filename, uint32_t *pixels, int32_t w, int32_t h, int32_t  channels);
 uint8_t bmp_write_file(FILE *fp, uint32_t *pixels, int32_t w, int32_t h, int32_t channels);
 
@@ -97,8 +99,29 @@ void save_image(Image* image, char* file_name)
 	fwrite(image->pixels, get_image_size(image), 1, file);
 }
 
+uint32_t *bmp_alpha_to_rgba_channels(uint8_t *src_image, int32_t w, int32_t h) {
+	uint8_t *dst_image = (uint8_t *)malloc(w * h * 4); // TODO: Make another function that takes in buffer instead of allocating
+
+	uint8_t *dst = dst_image;
+	uint8_t *src = src_image;
+	for (int y = 0; y < h; ++y) {
+		for (int x = 0; x < w; ++x) {
+			dst[0] = src[0];
+			dst[1] = src[0];
+			dst[2] = src[0];
+			dst[3] = src[0];
+			dst += 4;
+			src += 1;
+		}
+	}
+
+	return (uint32_t *)dst_image;
+}
+
 uint8_t bmp_write(const char *filename, uint32_t *pixels, int32_t w, int32_t h, int32_t channels)
 {
+	assert(channels == 3 || channels == 4);
+
 	Image image = {0};
 	
 	image.header.type = 0x4d42;
@@ -110,9 +133,9 @@ uint8_t bmp_write(const char *filename, uint32_t *pixels, int32_t w, int32_t h, 
 	image.header.width = w;
 	image.header.height = -h;
 	image.header.planes = 1;
-	image.header.bitcount = 32;
+	image.header.bitcount = (channels == 3 ? 24 : 32);
 	image.header.compression = 0;
-	image.header.size_image = 0;
+	image.header.size_image = w * h * channels;
 	image.header.x_pels_per_meter = 0;
 	image.header.y_pels_per_meter = 0;
 	image.header.clr_used = 0;


### PR DESCRIPTION
…l count for Bitmap

Support for 24 bit images
Added bmp_alpha_to_rgba_channels to change gray scale images to RGBA (this function allocates memory using malloc, we probably will want a function that takes buffer as a function parameter)